### PR TITLE
specify python engine to fix bug with df.query()

### DIFF
--- a/blurr/utils.py
+++ b/blurr/utils.py
@@ -102,7 +102,7 @@ class ModelHelper():
         query = ['model_task.notna()']
         if (arch): query.append(f'arch == "{arch}"')
 
-        return self._df.query(' & '.join(query)).model_task.unique().tolist()
+        return self._df.query(' & '.join(query), engine='python').model_task.unique().tolist()
 
     def get_models(self, arch=None, task=None):
         """The transformer models available for use (optional: by architecture | task)"""

--- a/nbs/00_utils.ipynb
+++ b/nbs/00_utils.ipynb
@@ -1144,18 +1144,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Converted 00_utils.ipynb.\n",
-      "Converted 01_data.ipynb.\n",
-      "Converted 02_modeling.ipynb.\n",
-      "Converted index.ipynb.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#hide\n",
     "from nbdev.export import notebook2script\n",

--- a/nbs/00_utils.ipynb
+++ b/nbs/00_utils.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -421,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -457,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -481,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -508,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -534,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -551,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -578,7 +578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -595,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -623,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1175,18 +1175,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/nbs/00_utils.ipynb
+++ b/nbs/00_utils.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
     "        query = ['model_task.notna()']\n",
     "        if (arch): query.append(f'arch == \"{arch}\"')\n",
     "\n",
-    "        return self._df.query(' & '.join(query)).model_task.unique().tolist()\n",
+    "        return self._df.query(' & '.join(query), engine='python').model_task.unique().tolist()\n",
     "    \n",
     "    def get_models(self, arch=None, task=None):\n",
     "        \"\"\"The transformer models available for use (optional: by architecture | task)\"\"\"\n",
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -314,7 +314,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>2</th>\n",
        "      <td>AdaptiveEmbedding</td>\n",
        "      <td>transformers.modeling_transfo_xl</td>\n",
        "      <td>transformers</td>\n",
@@ -326,7 +326,7 @@
        "      <td>None</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>3</th>\n",
        "      <td>AlbertConfig</td>\n",
        "      <td>transformers.configuration_albert</td>\n",
        "      <td>transformers</td>\n",
@@ -338,7 +338,7 @@
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>4</th>\n",
        "      <td>AlbertForMaskedLM</td>\n",
        "      <td>transformers.modeling_albert</td>\n",
        "      <td>transformers</td>\n",
@@ -350,7 +350,7 @@
        "      <td>ForMaskedLM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>5</th>\n",
        "      <td>AlbertForQuestionAnswering</td>\n",
        "      <td>transformers.modeling_albert</td>\n",
        "      <td>transformers</td>\n",
@@ -362,7 +362,7 @@
        "      <td>ForQuestionAnswering</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
+       "      <th>6</th>\n",
        "      <td>AlbertForSequenceClassification</td>\n",
        "      <td>transformers.modeling_albert</td>\n",
        "      <td>transformers</td>\n",
@@ -421,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -457,14 +457,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['transfo_xl', 'albert', 'auto', 'bart', 'bert', 'bert_japanese', 'ctrl', 'camembert', 'utils', 'distilbert', 'electra', 'flaubert', 'gpt2', 'mmbt', 'openai', 'encoder_decoder', 'roberta', 't5', 'xlm', 'xlm_roberta', 'xlnet']\n"
+      "['transfo_xl', 'albert', 'auto', 'bart', 'bert', 'bert_japanese', 'ctrl', 'camembert', 'utils', 'distilbert', 'electra', 'flaubert', 'gpt2', 'mmbt', 'openai', 'encoder_decoder', 'roberta', 't5', 'tf_transfo_xl', 'tf_albert', 'tf_auto', 'tf_bert', 'tf_ctrl', 'tf_camembert', 'tf_distilbert', 'tf_electra', 'tf_flaubert', 'tf_gpt2', 'tf_openai', 'tf_utils', 'tf_roberta', 'tf_t5', 'tf_xlm', 'tf_xlm_roberta', 'tf_xlnet', 'xlm', 'xlm_roberta', 'xlnet']\n"
      ]
     }
    ],
@@ -481,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,14 +491,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(#21) [<HF_ARCHITECTURES.transfo_xl: 1>,<HF_ARCHITECTURES.albert: 2>,<HF_ARCHITECTURES.auto: 3>,<HF_ARCHITECTURES.bart: 4>,<HF_ARCHITECTURES.bert: 5>,<HF_ARCHITECTURES.bert_japanese: 6>,<HF_ARCHITECTURES.ctrl: 7>,<HF_ARCHITECTURES.camembert: 8>,<HF_ARCHITECTURES.utils: 9>,<HF_ARCHITECTURES.distilbert: 10>...]\n"
+      "(#38) [<HF_ARCHITECTURES.transfo_xl: 1>,<HF_ARCHITECTURES.albert: 2>,<HF_ARCHITECTURES.auto: 3>,<HF_ARCHITECTURES.bart: 4>,<HF_ARCHITECTURES.bert: 5>,<HF_ARCHITECTURES.bert_japanese: 6>,<HF_ARCHITECTURES.ctrl: 7>,<HF_ARCHITECTURES.camembert: 8>,<HF_ARCHITECTURES.utils: 9>,<HF_ARCHITECTURES.distilbert: 10>...]\n"
      ]
     }
    ],
@@ -508,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -534,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -551,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -578,7 +578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -595,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -623,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1175,8 +1175,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/nbs/01_data.ipynb
+++ b/nbs/01_data.ipynb
@@ -1641,9 +1641,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "py374",
    "language": "python",
-   "name": "python3"
+   "name": "py374"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/nbs/01_data.ipynb
+++ b/nbs/01_data.ipynb
@@ -1644,18 +1644,6 @@
    "display_name": "py374",
    "language": "python",
    "name": "py374"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/nbs/02_modeling.ipynb
+++ b/nbs/02_modeling.ipynb
@@ -3138,9 +3138,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "py374",
    "language": "python",
-   "name": "python3"
+   "name": "py374"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/nbs/02_modeling.ipynb
+++ b/nbs/02_modeling.ipynb
@@ -3141,18 +3141,6 @@
    "display_name": "py374",
    "language": "python",
    "name": "py374"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
It looks like calling ModelHelper.get_tasks() gives this error. Specifying ```engine='python'``` in the query seems to fix it. This is my first PR to an nbdev project by the way, so let me know if I've missed a step in the process!
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-22-19b8480e1f79> in <module>
----> 1 print(mh.get_tasks())
      2 print('')
      3 print(mh.get_tasks('bart'))

<ipython-input-9-60d177160939> in get_tasks(self, arch)
     71         if (arch): query.append(f'arch == "{arch}"')
     72---> 73         return self._df.query(' & '.join(query)).model_task.unique().tolist()
     74     75     def get_models(self, arch=None, task=None):

~/.pyenv/versions/3.7.4/envs/py374/lib/python3.7/site-packages/pandas/core/frame.py in query(self, expr, inplace, **kwargs)
   3229         kwargs["level"] = kwargs.pop("level", 0) + 1
   3230         kwargs["target"] = None
-> 3231         res = self.eval(expr, **kwargs)
   3232   3233         try:

~/.pyenv/versions/3.7.4/envs/py374/lib/python3.7/site-packages/pandas/core/frame.py in eval(self, expr, inplace, **kwargs)
   3344         kwargs["resolvers"] = kwargs.get("resolvers", ()) + tuple(resolvers)
   3345-> 3346         return _eval(expr, inplace=inplace, **kwargs)
   3347   3348     def select_dtypes(self, include=None, exclude=None) -> "DataFrame":

~/.pyenv/versions/3.7.4/envs/py374/lib/python3.7/site-packages/pandas/core/computation/eval.py in eval(expr, parser, engine, truediv, local_dict, global_dict, resolvers, level, target, inplace)
    335         eng = _engines[engine]
    336         eng_inst = eng(parsed_expr)
--> 337         ret = eng_inst.evaluate()
    338    339         if parsed_expr.assigner is None:

~/.pyenv/versions/3.7.4/envs/py374/lib/python3.7/site-packages/pandas/core/computation/engines.py in evaluate(self)
     71     72         # make sure no names in resolvers and locals/globals clash
---> 73         res = self._evaluate()
     74         return reconstruct_object(
     75             self.result_type, res, self.aligned_axes, self.expr.terms.return_type

~/.pyenv/versions/3.7.4/envs/py374/lib/python3.7/site-packages/pandas/core/computation/engines.py in _evaluate(self)
    111         env = self.expr.env
    112         scope = env.full_scope
--> 113         _check_ne_builtin_clash(self.expr)
    114         return ne.evaluate(s, local_dict=scope)
    115~/.pyenv/versions/3.7.4/envs/py374/lib/python3.7/site-packages/pandas/core/computation/engines.py in _check_ne_builtin_clash(expr)
     27         Terms can contain
     28     """
---> 29     names = expr.names
     30     overlap = names & _ne_builtins
     31~/.pyenv/versions/3.7.4/envs/py374/lib/python3.7/site-packages/pandas/core/computation/expr.py in names(self)
    785         """Get the names in an expression"""
    786         if is_term(self.terms):
--> 787             return frozenset([self.terms.name])
    788         return frozenset(term.name for term in com.flatten(self.terms))
    789~/.pyenv/versions/3.7.4/envs/py374/lib/python3.7/site-packages/pandas/core/generic.py in __hash__(self)
   1797     def __hash__(self):
   1798         raise TypeError(
-> 1799             f"{repr(type(self).__name__)} objects are mutable, "
   1800             f"thus they cannot be hashed"
   1801         )

TypeError: 'Series' objects are mutable, thus they cannot be hashed
```