### PR TITLE
Fix store_attr parameters wrong order

### DIFF
--- a/blurr/data/core.py
+++ b/blurr/data/core.py
@@ -20,8 +20,8 @@ class HF_TokenizerTransform(ItemTransform):
         # gpt2, roberta, bart (and maybe others) tokenizers require a prefix space
         if (hasattr(hf_tokenizer, 'add_prefix_space')): kwargs['add_prefix_space'] = True
 
-        store_attr(self, 'hf_arch, hf_tokenizer, is_pretokenized, max_length, padding, truncation')
-        store_attr(self, 'kwargs')
+        store_attr(self=self, names='hf_arch, hf_tokenizer, is_pretokenized, max_length, padding, truncation')
+        store_attr(self=self, names='kwargs')
 
     def encodes(self, inp):
         """Supports passing in one or two input sequences, or a list[str] (the later is common for token
@@ -56,7 +56,7 @@ class HF_BatchTransform(Transform):
     HF_TokenizerTransform inputs
     """
     def __init__(self, hf_arch, hf_tokenizer, hf_input_return_type=HF_BaseInput, **kwargs):
-        store_attr(self, 'hf_arch, hf_tokenizer, hf_input_return_type, kwargs')
+        store_attr(self=self, names='hf_arch, hf_tokenizer, hf_input_return_type, kwargs')
 
     def encodes(self, samples): return samples
 

--- a/blurr/modeling/question_answering.py
+++ b/blurr/modeling/question_answering.py
@@ -24,7 +24,7 @@ class MultiTargetLoss(Module):
                  weights=[1, 1], reduction='mean'):
 
         loss_funcs = [ cls(reduction=reduction, **kwargs) for cls, kwargs in zip(loss_classes, loss_classes_kwargs) ]
-        store_attr(self, 'loss_funcs, weights')
+        store_attr(self=self, names='loss_funcs, weights')
         self._reduction = reduction
 
     # custom loss function must have either a reduction attribute or a reduction argument (like all fastai and

--- a/blurr/modeling/summarization.py
+++ b/blurr/modeling/summarization.py
@@ -29,7 +29,7 @@ class HF_SummarizationModelCallback(HF_BaseModelCallback):
     def __init__(self, rouge_metrics=["rouge1", "rouge2", "rougeL"], text_gen_kwargs={}, **kwargs):
         self.run_before = Recorder
 
-        store_attr(self, 'rouge_metrics, text_gen_kwargs, kwargs')
+        store_attr(self=self, names='rouge_metrics, text_gen_kwargs, kwargs')
         self.custom_metrics_dict = { k:None for k in rouge_metrics }
 
         self.do_setup = True

--- a/blurr/modeling/text_generation.py
+++ b/blurr/modeling/text_generation.py
@@ -29,7 +29,7 @@ class HF_TextGenModelCallback(HF_BaseModelCallback):
     def __init__(self, rouge_metrics=["rouge1", "rouge2", "rougeL"], text_gen_kwargs={}, **kwargs):
         self.run_before = Recorder
 
-        store_attr(self, 'rouge_metrics, text_gen_kwargs, kwargs')
+        store_attr(self=self, names='rouge_metrics, text_gen_kwargs, kwargs')
         self.custom_metrics_dict = { k:None for k in rouge_metrics }
 
         self.do_setup = True

--- a/blurr/modeling/token_classification.py
+++ b/blurr/modeling/token_classification.py
@@ -33,7 +33,7 @@ class HF_TokenClassCallback(HF_BaseModelCallback):
     def __init__(self, tok_metrics=["accuracy", "precision", "recall", "f1"], **kwargs):
         self.run_before = Recorder
 
-        store_attr(self, 'tok_metrics, kwargs')
+        store_attr(self=self, names='tok_metrics, kwargs')
         self.custom_metrics_dict = { k:None for k in tok_metrics }
 
         self.do_setup = True


### PR DESCRIPTION
### Issue
https://github.com/ohmeow/blurr/issues/10

### Bug
store_attr implementation: `def store_attr(names=None, self=None, but=None, **attrs):`
store_attr call in ohmeow_blurr: `store_attr(self, 'hf_arch, hf_tokenizer, hf_input_return_type, kwargs')`

### Fix
Named parameters