### PR TITLE
fix: bullet list of supported tasks formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ variety of tasks. It includes a high, mid, and low-level API that will
 allow developers to use much of it out-of-the-box or customize it as
 needed.
 
-**Supported Text/NLP Tasks**: - Sequence Classification  
+**Supported Text/NLP Tasks**: 
+- Sequence Classification  
 - Token Classification  
 - Question Answering  
 - Summarization  


### PR DESCRIPTION
The first element of the list Is missing a new line before it, and thus shows up in a place some people may not see.