### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ seqeval
 rouge-score 
 openpyxl>=3.0.7,<4.0 
 xlrd>=2.0.1,<3.0
+torch>=2.0
 
 ipykernel 
 nbdev 


### PR DESCRIPTION
Ensure compatibility with torchdata by specifying torch>=2.0 in requirements.txt. This update resolves dependency conflicts that were causing torch to be downgraded to 1.13.1.